### PR TITLE
Changes to elasticsearch resource

### DIFF
--- a/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
@@ -64,7 +64,7 @@ public class BatchElasticsearchSink extends ReferenceBatchSink<StructuredRecord,
     job.setSpeculativeExecution(false);
 
     conf.set("es.nodes", config.hostname);
-    conf.set("es.resource", String.format("%s/%s", config.index, config.type));
+    conf.set("es.resource.write", String.format("%s/%s", config.index, config.type));
     conf.set("es.input.json", "yes");
     conf.set("es.mapping.id", config.idField);
 
@@ -73,7 +73,6 @@ public class BatchElasticsearchSink extends ReferenceBatchSink<StructuredRecord,
 
   @Override
   public void transform(StructuredRecord record, Emitter<KeyValue<Writable, Writable>> emitter) throws Exception {
-    Text text = new Text(StructuredRecordStringConverter.toJsonString(record));
     emitter.emit(new KeyValue<Writable, Writable>(new Text(StructuredRecordStringConverter.toJsonString(record)),
                                                   new Text(StructuredRecordStringConverter.toJsonString(record))));
   }

--- a/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
@@ -82,7 +82,7 @@ public class ElasticsearchSource extends ReferenceBatchSource<Text, MapWritable,
 
     job.setSpeculativeExecution(false);
     conf.set("es.nodes", config.hostname);
-    conf.set("es.resource", getResource());
+    conf.set("es.resource.read", getResource());
     conf.set("es.query", config.query);
     job.setMapOutputKeyClass(Text.class);
     job.setMapOutputValueClass(MapWritable.class);


### PR DESCRIPTION
Issue: When we have Elasticsearch source and sink in the same job, `es.resource` gets overridden by source. Elasticsearch has separate properties if we want to read and write to same elasticsearch server in same job.

Reference doc: https://www.elastic.co/guide/en/elasticsearch/hadoop/current/configuration.html